### PR TITLE
Update to use netcoreapp2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ If you need to use a private build of the JIT or other CoreCLR components, now i
 
 Build/publish MusicStore
 
-`dotnet publish -c Release -f netcoreapp12`
+`dotnet publish -c Release -f netcoreapp20`
 
 **Step 5:** 
 
 Run crossgen on the publish output
 
-`cd bin\Release\netcoreapp12\publish`
+`cd bin\Release\netcoreapp20\publish`
 
 **If you are using a private build of the JIT**
 

--- a/src/MusicStore/Get-Crossgen.ps1
+++ b/src/MusicStore/Get-Crossgen.ps1
@@ -19,7 +19,7 @@ function Get-CoreCLRVersion()
 {
     if (-not (Test-Path $PSScriptRoot\obj\project.assets.json))
     {
-        Write-Error "project.lock.json is missing. do a dotnet restore."
+        Write-Error "project.assets.json is missing. do a dotnet restore."
         exit
     }
     
@@ -32,9 +32,9 @@ function Get-CoreCLRVersion()
 
     foreach ($name in $json["libraries"].Keys)
     {
-        if ($name.StartsWith("Microsoft.NETCore.Runtime.CoreCLR/"))
+        if ($name.StartsWith("Microsoft.NETCore.Targets/"))
         {
-            $version = $name.SubString("Microsoft.NETCore.Runtime.CoreCLR/".Length)
+            $version = $name.SubString("Microsoft.NETCore.Targets/".Length)
             break
         }
     }

--- a/src/MusicStore/MusicStore.csproj
+++ b/src/MusicStore/MusicStore.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <Description>Music store application on ASP.NET 5</Description>
-    <TargetFramework>netcoreapp1.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <DefineConstants>$(DefineConstants);DEMO</DefineConstants>
     <WarningsAsErrors>true</WarningsAsErrors>
     <PreserveCompilationContext>true</PreserveCompilationContext>
@@ -23,9 +23,9 @@
     </Content>
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.2' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.NetCore.App">
-      <Version>1.2.0-*</Version>
+      <Version>2.0.0-*</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
The tools downloaded by Dotnet-Install.ps1 now seem to require this.

Also update Get-Crossgen.ps1 to look for Microsoft.NETCore.Targets so it
can continue finding the version string.