### PR TITLE
Fix Microsoft.NET.Sdk.Web casing for linux

### DIFF
--- a/src/MusicStore/MusicStore.csproj
+++ b/src/MusicStore/MusicStore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Description>Music store application on ASP.NET 5</Description>


### PR DESCRIPTION
Before this change, "dotnet restore" fails on linux with the following error:

`MusicStore.csproj : error MSB4019: The imported project "/home/sven/bin/sdk/2.0.0-preview1-005685/Sdks/Microsoft.Net.Sdk.Web/Sdk/Sdk.props" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.`


```
ls ~/bin/sdk/2.0.0-preview1-005685/Sdks/
FSharp.NET.Sdk  Microsoft.NET.Sdk  Microsoft.NET.Sdk.Publish  Microsoft.NET.Sdk.Web  Microsoft.NET.Sdk.Web.ProjectSystem  NuGet.Build.Tasks.Pack
```