### PR TITLE
Enable JitBench to run under the xUnit-Performance API in order to capture ETW events

### DIFF
--- a/src/MusicStore/Invoke-Crossgen.ps1
+++ b/src/MusicStore/Invoke-Crossgen.ps1
@@ -6,7 +6,8 @@ param(
     [string]$crossgen_path = $null, 
     [string]$runtime = "win7-x64",
     [string]$sdk_version = "1.1.0-preview1-001100-00",
-    [string]$sdk_path = $null)
+    [string]$sdk_path = $null,
+    [string]$dotnet_dir = $null)
 
 $ErrorActionPreference = "Stop"
 
@@ -14,7 +15,11 @@ $lib_paths = @()
 
 $excludes = @("MusicStore.dll")
 
-$dotnet_dir = (Get-Item (Get-Command dotnet).Path).Directory
+if ($dotnet_dir -eq $null) {
+    $dotnet_dir = (Get-Item (Get-Command dotnet).Path).Directory
+}
+
+# $dotnet_dir = $dotnet_dir == null ? (Get-Item (Get-Command dotnet).Path).Directory : $dotnet_dir
 $config = (Get-Content MusicStore.runtimeconfig.json -Raw) | ConvertFrom-Json
 $shared_fx_version = $config.runtimeOptions.framework.version
 $shared_fx_path = [io.path]::combine($dotnet_dir, "shared\Microsoft.NETCore.App", $shared_fx_version)

--- a/src/MusicStore/Program.cs
+++ b/src/MusicStore/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data.SqlClient;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
@@ -38,6 +39,7 @@ namespace MusicStore
             Console.WriteLine("Server started in {0}ms", serverStartupTime);
             Console.WriteLine();
 
+            long r;
             using (var client = new HttpClient())
             {
                 Console.WriteLine("Starting request to http://localhost:5000");
@@ -47,44 +49,17 @@ namespace MusicStore
                 var firstRequestTime = requestTime.ElapsedMilliseconds;
 
                 Console.WriteLine("Response: {0}", response.StatusCode);
-                Console.WriteLine("Request took {0}ms", firstRequestTime);
-                Console.WriteLine();
-                Console.WriteLine("Cold start time (server start + first request time): {0}ms", serverStartupTime + firstRequestTime);
-                Console.WriteLine();
-                Console.WriteLine();
-                
-                var minRequestTime = long.MaxValue;
-                var maxRequestTime = long.MinValue;
-                var averageRequestTime = 0.0;
-
-                Console.WriteLine("Running 100 requests");
-                for(int i = 1; i <= 100; ++i)
-                {
-                    requestTime.Restart();
-                    response = client.GetAsync("http://localhost:5000").Result;
-                    requestTime.Stop();
-
-                    var requestTimeElapsed = requestTime.ElapsedMilliseconds;
-                    if (requestTimeElapsed < minRequestTime)
-                    {
-                        minRequestTime = requestTimeElapsed;
-                    }
-
-                    if (requestTimeElapsed > maxRequestTime)
-                    {
-                        maxRequestTime = requestTimeElapsed;
-                    }
-
-                    // Rolling average of request times
-                    averageRequestTime = (averageRequestTime * ((i - 1.0) / i)) + (requestTimeElapsed * (1.0 / i));
-                }
-
-                Console.WriteLine("Steadystate min response time: {0}ms", minRequestTime);
-                Console.WriteLine("Steadystate max response time: {0}ms", maxRequestTime);
-                Console.WriteLine("Steadystate average response time: {0}ms", (int)averageRequestTime);
+                Console.WriteLine("Request took {0}ms", requestTime.ElapsedMilliseconds);
+                r = requestTime.ElapsedMilliseconds;
             }
 
             Console.WriteLine();
+            
+            using (StreamWriter file = new StreamWriter(File.Create(@"measures.txt")))
+            {
+                file.WriteLine(totalTime.ElapsedMilliseconds + " " + r);
+                Console.WriteLine("Startup time and request time writen to measures.txt.");
+            }
         }
     }
 }

--- a/src/MusicStore/buildAndRun.ps1
+++ b/src/MusicStore/buildAndRun.ps1
@@ -1,0 +1,23 @@
+dotnet restore; 
+
+if ($LastExitCode -ne 0)
+{
+    throw "dotnet restore failed."
+}
+
+dotnet publish -c Release -f netcoreapp10; 
+
+if ($LastExitCode -ne 0)
+{
+    throw "dotnet publish failed."
+}
+
+cd .\bin\Release\netcoreapp1.0\publish\; 
+
+.\Invoke-Crossgen.ps1; &'C:\Program Files\dotnet\dotnet.exe' .\MusicStore.dll; 
+
+if ($LastExitCode -ne 0)
+{
+    throw "Invoke-Crossgen failed."
+}
+cd ..\..\..\..  


### PR DESCRIPTION
- Change JitBench to perform as a xUnit performance test [xUnit-Performance API](https://github.com/Microsoft/xunit-performance).
- Changing JitBench to output the startup time and single request time to a file.
- Adding a parameter for Invoke_Crossgen, so we can specify a specific location of dotnet.
- The rest of the functionality remains the same.