### PR TITLE
Add a dotnet store workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 [Bb]in/
 .dotnet/
 .aspnet/
+.store/
+.packages/
 .vs/
 *.xap
 *.user

--- a/AspNet-GenerateStore.ps1
+++ b/AspNet-GenerateStore.ps1
@@ -1,0 +1,58 @@
+[cmdletbinding()]
+param(
+    [string] $InstallDir = "<auto>",
+    [string] $AspNetVersion = "<auto>",
+    [string] $Framework = "netcoreapp2.0",
+    [string] $FrameworkVersion = "<auto>",
+    [string] $Architecture = "x64",
+    [string] $Runtime = "win7-x64",
+    [string] $Feed = "https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json")
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference="Stop"
+$ProgressPreference="SilentlyContinue"
+
+. "$(Split-Path $MyInvocation.MyCommand.Path -Parent)\AspNet-Shared.ps1"
+
+# Create the installation directory and normalize to a fully qualified path
+$InstallDir = New-InstallDirectory -Directory $InstallDir -Default ".store" -Clean -Create
+
+# Blow away .temp - this will be used as a working directory by dotnet store, but it's
+# bad at cleaning up after itself.
+$temp = New-InstallDirectory -Directory "<auto>" -Default ".temp" -Clean
+
+if ($FrameworkVersion -eq "<auto>")
+{
+    $FrameworkVersion = Get-FrameworkVersion
+}
+
+if ($AspNetVersion -eq "<auto>")
+{
+    $AspNetVersion = Get-LatestAspNetVersion -InstallDir "<auto>"
+}
+
+# These environment variables are used by CreateStore.proj
+$env:JITBENCH_ASPNET_VERSION = $AspNetVersion
+$env:JITBENCH_FRAMEWORK_VERSION = $FrameworkVersion
+
+Write-Host -ForegroundColor Green "Running dotnet store"
+& "dotnet" "store", "--manifest", ".\CreateStore.proj", "-f", "$Framework", "-r" "$Runtime" "--framework-version", "$FrameworkVersion", "-w", $temp, "-o", "$InstallDir"
+if ($LastExitCode -ne 0)
+{
+    throw "dotnet store failed."
+}
+
+$BinariesDirectory = $InstallDir
+$Manifest = [System.IO.Path]::Combine($InstallDir, $Architecture, $Framework, 'artifact.xml')
+
+Write-Host -ForegroundColor Green "Setting JITBENCH_ASPNET_VERSION to $AspNetVersion"
+$env:JITBENCH_ASPNET_VERSION = $AspNetVersion
+
+Write-Host -ForegroundColor Green "Setting JITBENCH_FRAMEWORK_VERSION to $FrameworkVersion"
+$env:JITBENCH_FRAMEWORK_VERSION = $FrameworkVersion
+
+Write-Host -ForegroundColor Green "Setting JITBENCH_ASPNET_MANIFEST to $Manifest"
+$env:JITBENCH_ASPNET_MANIFEST = $Manifest
+
+Write-Host -ForegroundColor Green "Setting DOTNET_SHARED_STORE to $BinariesDirectory"
+$env:DOTNET_SHARED_STORE = $BinariesDirectory

--- a/AspNet-Shared.ps1
+++ b/AspNet-Shared.ps1
@@ -1,0 +1,158 @@
+# Shared functions used by various scripts
+
+# Creates a directory if it doesn't exist, returns the fully qualified path
+function New-InstallDirectory(
+    [string] $Directory,
+    [string] $Default,
+    [switch] $Clean = $false,
+    [switch] $Create = $false)
+{
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference="Stop"
+    $ProgressPreference="SilentlyContinue"
+
+    if (-not $Directory)
+    {
+        throw "Directory is required. Use <auto> to generate a default."
+    }
+
+    if (-not $Default)
+    {
+        throw "Default is required."
+    }
+
+    if ($Directory -eq "<auto>")
+    {
+        $Directory = Join-Path "$(Split-Path $script:MyInvocation.MyCommand.Path -Parent)" $Default
+    }
+
+    if ($Clean -and (Test-Path $Directory))
+    {
+        Remove-Item $Directory -Recurse -Force | Out-Null
+    }
+
+    if ($Create -and (-not (Test-Path $Directory)))
+    {
+        New-Item -ItemType Directory -Force -Path $Directory | Out-Null
+    }
+
+    $Directory = [System.IO.Path]::GetFullPath($Directory)
+    return $Directory
+}
+
+# Finds the latests installed shared framework
+function Get-FrameworkVersion()
+{
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference="Stop"
+    $ProgressPreference="SilentlyContinue"
+
+    Write-Host -ForegroundColor Green "Autodetecting .NET version"
+
+    $dotnet = [System.IO.Path]::GetDirectoryName((Get-Command dotnet).Path)
+    $shared_framework_root = [System.IO.Path]::Combine($dotnet, "shared\Microsoft.NETCore.App")
+
+    $versions = @(Get-ChildItem $shared_framework_root | Sort-Object Name)
+
+    foreach ($version in $versions)
+    {
+        Write-Host -ForegroundColor Green "Found version: $version"
+    }
+    
+    Write-Host -ForegroundColor Green "Choosing version: $($versions[-1])"
+    return $version[-1]
+}
+
+function Get-LatestAspNetVersion([string] $InstallDir)
+{
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference="Stop"
+    $ProgressPreference="SilentlyContinue"
+
+    if (-not $InstallDir)
+    {
+        throw "InstallDir is required. Use <auto> to generate a default."
+    }
+
+    $InstallDir = New-InstallDirectory -Directory $InstallDir -Default ".packages" -Create
+
+    $project = "$(Split-Path $script:MyInvocation.MyCommand.Path -Parent)\GetLatestAspNetVersion.proj"
+
+    Write-Host -ForegroundColor Green "Autodetecting ASP.NET version"
+    & "dotnet" "restore", "$project", "--packages", "$InstallDir" | Write-Host
+    if ($LastExitCode -ne 0)
+    {
+        throw "dotnet restore failed."
+    }
+
+    $version = Get-LatestPackageVersion -PackagesRoot $InstallDir -Package "microsoft.aspnetcore.all"
+    return $version
+}
+
+function Get-LatestPackageVersion(
+    [string] $PackagesRoot,
+    [string] $Package)
+{
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference="Stop"
+    $ProgressPreference="SilentlyContinue"
+
+    if (-not $PackagesRoot)
+    {
+        throw "PackagesRoot is required."
+    }
+
+    if (-not $Package)
+    {
+        throw "Package is required."
+    }
+
+    $package_dir = Join-Path $PackagesRoot $Package
+    if (-not (Test-Path $package_dir))
+    {
+        throw "$Package not found."
+    }
+
+    $versions = @(Get-ChildItem $package_dir | Sort-Object Name)
+
+    foreach ($version in $versions)
+    {
+        Write-Host -ForegroundColor Green "Found version: $version"
+    }
+    
+    Write-Host -ForegroundColor Green "Choosing version: $($versions[-1])"
+    return $versions[-1]
+}
+
+# Downloads NuGet.exe
+function Get-NuGet(
+    [string] $InstallDir,
+    [string] $Url = "https://dist.nuget.org/win-x86-commandline/v4.1.0/NuGet.exe")
+{
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference="Stop"
+    $ProgressPreference="SilentlyContinue"
+
+    if (-not $InstallDir)
+    {
+        throw "InstallDir is required."
+    }
+
+    if (-not (Test-Path $InstallDir))
+    {
+        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    }
+
+    $nuget = Join-Path $InstallDir "NuGet.exe"
+
+    if (-not (Test-Path $nuget))
+    {
+        Write-Host -ForegroundColor Green "Getting NuGet from $Url"
+
+        $wc = New-Object System.Net.WebClient
+        $wc.DownloadFile($Url, $nuget)
+    }
+    
+    return $nuget
+}
+

--- a/CreateStore.proj
+++ b/CreateStore.proj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AspNetCoreVersion>$(JITBENCH_ASPNET_VERSION)</AspNetCoreVersion>
+    <RuntimeFrameworkVersion>$(JITBENCH_ASPNET_VERSION)</RuntimeFrameworkVersion>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
+  </ItemGroup>
+</Project>

--- a/GetLatestAspNetVersion.proj
+++ b/GetLatestAspNetVersion.proj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
+    <RuntimeFrameworkVersion>2.0.0-*</RuntimeFrameworkVersion>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="$(AspNetCoreVersion)" PrivateAssets="None" />
+  </ItemGroup>
+</Project>

--- a/src/MusicStore/MusicStore.csproj
+++ b/src/MusicStore/MusicStore.csproj
@@ -12,12 +12,16 @@
     <!-- This will prevent our build system from trying to package this project. -->
     <IsPackable>false</IsPackable>
     
-    <!-- This will be set as an environment variable to pin the package version. -->
+    <!-- This will be set as an environment variable to pin the version. -->
     <AspNetVersion>$(JITBENCH_ASPNET_VERSION)</AspNetVersion>
+    <RuntimeFrameworkVersion>$(JITBENCH_FRAMEWORK_VERSION)</RuntimeFrameworkVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(AspNetVersion)' == '' ">
     <AspNetVersion>2.0.0-*</AspNetVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RuntimeFrameworkVersion)' == '' ">
+    <RuntimeFrameworkVersion>2.0.0-*</RuntimeFrameworkVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This change adds support for `dotnet store` to generate crossgen/R2R
images on the test machine. This is an alternative to AspNet-Install
script, which uses pre-optimized binaries.

See the instructions for details.

I also fixed some issues where we could potentially restore versions of
the shared framework that aren't available. This would block the ability
to do comparisons between builds of the runtime. I fixed this by using the
same 'pinning' technique that's used for the asp.net libraries. See the
readme for details on this.