### PR TITLE
Change name of an EventId to fix build

### DIFF
--- a/src/MusicStore/Models/MusicStoreContext.cs
+++ b/src/MusicStore/Models/MusicStoreContext.cs
@@ -27,7 +27,7 @@ namespace MusicStore.Models
             base.OnConfiguring(optionsBuilder);
 
             // Suppresses a warning about DbContext.Genres.Select(g => g.Name).Take(9).ToListAsync()
-            optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.CompilingQueryModel));
+            optionsBuilder.ConfigureWarnings(w => w.Ignore(CoreEventId.QueryModelCompiling));
         }
 
         public DbSet<Album> Albums { get; set; }


### PR DESCRIPTION
After updating to the latest cli, I wasn't able to build musicstore because CoreEventId.CompilingQueryModel was renamed to QueryModelCompiling in
https://github.com/aspnet/EntityFramework/commit/4d96eb0cee0029d56605f51266e4ddb38ffe2efc.

@rynowak PTAL