### PR TITLE
Fix crossgen

### DIFF
--- a/CreateStore.proj
+++ b/CreateStore.proj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AspNetCoreVersion>$(JITBENCH_ASPNET_VERSION)</AspNetCoreVersion>
-    <RuntimeFrameworkVersion>$(JITBENCH_ASPNET_VERSION)</RuntimeFrameworkVersion>
+    <AspNetVersion>$(JITBENCH_ASPNET_VERSION)</AspNetVersion>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/MusicStore/MusicStore.csproj
+++ b/src/MusicStore/MusicStore.csproj
@@ -25,6 +25,15 @@
   </PropertyGroup>
   
   <ItemGroup>
+
+    <!-- This is a workaround for https://github.com/aspnet/JitBench/issues/34 -->
+    <PackageReference Include="Microsoft.Win32.Registry">
+      <Version>4.4.0-*</Version>
+    </PackageReference>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource">
+      <Version>4.4.0-*</Version>
+    </PackageReference>
+
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies">
       <Version>$(AspNetVersion)</Version>
     </PackageReference>


### PR DESCRIPTION
I made a mistake editing the set of libraries that we crossgen. These
were copied from the csproj, and they use a different MSBuild variable
to set the version oops.

As a result we were getting the 1.0.0 versions in the store and they
didn't match what the app was looking for.