### PR TITLE
Raise the file handle limit for osx

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -6,6 +6,7 @@ cd $root
 runtime="ubuntu.14.04-x64"
 if [ "$TRAVIS_OS_NAME" = "osx" ]
 then
+    ulimit -n 2048
     runtime="osx.10.12-x64"
 fi
 


### PR DESCRIPTION
This is a common workaround for 'too many open files' which is causing
our validation on OSX to fail.