### PR TITLE
Adding verification that we use crossgen-ed binaries

### DIFF
--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -2,7 +2,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference="Stop"
 $ProgressPreference="SilentlyContinue"
 
-cd "$(Split-Path $script:MyInvocation.MyCommand.Path -Parent)"
+Set-Location "$(Split-Path $script:MyInvocation.MyCommand.Path -Parent)"
 
 Write-Host -ForegroundColor Green "Installing latest dotnet"
 .\Dotnet-Install.ps1 -InstallDir .dotnet -Channel master -Architecture x64
@@ -11,12 +11,20 @@ Write-Host -ForegroundColor Green "Creating package store"
 .\AspNet-GenerateStore.ps1 -InstallDir .store -Architecture x64 -Runtime win7-x64
 
 Write-Host -ForegroundColor Green "Restoring MusicStore"
-cd src\MusicStore
+Set-Location src\MusicStore
 dotnet restore
 
 Write-Host -ForegroundColor Green "Publishing MusicStore"
 dotnet publish -c Release -f netcoreapp2.0 --manifest $env:JITBENCH_ASPNET_MANIFEST
 
 Write-Host -ForegroundColor Green "Running MusicStore"
-cd bin\Release\netcoreapp2.0\publish
-dotnet .\MusicStore.dll
+Set-Location bin\Release\netcoreapp2.0\publish
+dotnet .\MusicStore.dll | Tee-Object -Variable output
+
+if (-not ($output.Contains("ASP.NET loaded from store")))
+{
+    Write-Host -ForegroundColor Yellow "ASP.NET was not loaded from the store. This is a bug."
+    throw "ASP.NET was not loaded from the store. This is a bug."
+}
+
+Write-Host -ForegroundColor Green "Success"

--- a/src/MusicStore/Program.cs
+++ b/src/MusicStore/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
+using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 
@@ -85,6 +86,25 @@ namespace MusicStore
             }
 
             Console.WriteLine();
+
+            VerifyLibraryLocation();
+        }
+
+        private static void VerifyLibraryLocation()
+        {
+            var hosting = typeof(WebHostBuilder).GetTypeInfo().Assembly.Location;
+            var musicStore = typeof(Program).GetTypeInfo().Assembly.Location;
+
+            if (Path.GetDirectoryName(hosting) == Path.GetDirectoryName(musicStore))
+            {
+                Console.WriteLine("ASP.NET loaded from bin. This is a bug if you wanted crossgen");
+                Console.WriteLine("ASP.NET loaded from bin. This is a bug if you wanted crossgen");
+                Console.WriteLine("ASP.NET loaded from bin. This is a bug if you wanted crossgen");
+            }
+            else
+            {
+                Console.WriteLine("ASP.NET loaded from store");
+            }
         }
     }
 }

--- a/travis.sh
+++ b/travis.sh
@@ -27,4 +27,12 @@ dotnet publish -c Release -f netcoreapp2.0 --manifest $JITBENCH_ASPNET_MANIFEST
 
 echo "Running MusicStore"
 cd bin/Release/netcoreapp2.0/publish
-dotnet ./MusicStore.dll
+output=$(dotnet ./MusicStore.dll | tee /dev/tty; exit ${PIPESTATUS[0]})
+
+if [[ "$output" != *"ASP.NET loaded from store"* ]]
+then
+    echo "ASP.NET was not loaded from the store. This is a bug."
+    exit 1
+fi
+
+echo "Success"


### PR DESCRIPTION
/cc @davmason - if you have any scripts for automating this, you should add a similar check

Currently working on adding the equivalent for *nix