### PR TITLE
Remove references to DisplayName.

### DIFF
--- a/src/MusicStore/Startup.cs
+++ b/src/MusicStore/Startup.cs
@@ -124,7 +124,6 @@ namespace MusicStore
             // dnx . web
             services.AddMicrosoftAccountAuthentication(options =>
             {
-                options.DisplayName = "MicrosoftAccount - Requires project changes";
                 options.ClientId = "000000004012C08A";
                 options.ClientSecret = "GaMQ2hCnqAC6EcDLnXsAeBVIJOLmeutL";
             });


### PR DESCRIPTION
This fixes the musicstore build by removing the reference to
DisplayName as in

https://github.com/aspnet/MusicStore/commit/ddd69e5fdf34106d70b5ca7da0eb8b9c96f3964c.

DisplayName was removed as part of the aspnet auth changes:

https://github.com/aspnet/Security/pull/1170/files#diff-53acb34a3721dd81564b4b3b488ffc0cL22