### PR TITLE
Use the metapackage

### DIFF
--- a/CreateStore.proj
+++ b/CreateStore.proj
@@ -5,73 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Session">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
+    <PackageReference Include="Microsoft.AspNetCore.All">
       <Version>$(AspNetVersion)</Version>
     </PackageReference>
   </ItemGroup>

--- a/src/MusicStore/MusicStore.csproj
+++ b/src/MusicStore/MusicStore.csproj
@@ -40,73 +40,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Session">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console">
-      <Version>$(AspNetVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
+    <PackageReference Include="Microsoft.AspNetCore.All">
       <Version>$(AspNetVersion)</Version>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
This swaps out a list of individual package references for the ASP.NET metapackage. There are some warnings now on publish, but this should resolve the dramatically increased time we're seeing for `dotnet store` to run.