### PR TITLE
Jitbench fixes

### DIFF
--- a/AspNet-CopyPrivateCoreCLR.ps1
+++ b/AspNet-CopyPrivateCoreCLR.ps1
@@ -1,0 +1,39 @@
+[cmdletbinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $BinDirPath,
+    [string] $InstallDir = "<auto>")
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference="Stop"
+$ProgressPreference="SilentlyContinue"
+
+if($InstallDir -eq "<auto>")
+{
+    $InstallDir = "$(Split-Path $MyInvocation.MyCommand.Path -Parent)\.dotnet"
+}
+
+$FramworkVersion = $env:JITBENCH_FRAMEWORK_VERSION
+$TargetPath = "$InstallDir\shared\Microsoft.NETCore.App\$FramworkVersion"
+
+function Copy-Private-File {
+    Param($FileName)
+    if(-not (Test-Path $TargetPath\$FileName.original))
+    {
+        Write-Host "copy $TargetPath\$FileName $TargetPath\$FileName.original"
+        copy $TargetPath\$FileName $TargetPath\$FileName.original
+    }
+    Write-Host "copy $BinDirPath\$FileName $TargetPath\$FileName"
+    copy $BinDirPath\$FileName $TargetPath\$FileName 
+}
+
+Copy-Private-File -FileName "coreclr.dll"
+Copy-Private-File -FileName "clrjit.dll"
+Copy-Private-File -FileName "mscordaccore.dll"
+Copy-Private-File -FileName "mscordbi.dll"
+Copy-Private-File -FileName "sos.dll"
+Copy-Private-File -FileName "sos.NETCore.dll"
+Copy-Private-File -FileName "clretwrc.dll"
+Copy-Private-File -FileName "System.Private.CoreLib.dll"
+Copy-Private-File -FileName "mscorrc.debug.dll"
+Copy-Private-File -FileName "mscorrc.dll"

--- a/AspNet-GenerateStore.ps1
+++ b/AspNet-GenerateStore.ps1
@@ -1,9 +1,6 @@
 [cmdletbinding()]
 param(
     [string] $InstallDir = "<auto>",
-    [string] $AspNetVersion = "2.0.0",
-    [string] $Framework = "netcoreapp2.1",
-    [string] $FrameworkVersion = "<auto>",
     [string] $Architecture = "x64",
     [string] $Runtime = "win7-x64")
 
@@ -20,38 +17,18 @@ $InstallDir = New-InstallDirectory -Directory $InstallDir -Default ".store" -Cle
 # bad at cleaning up after itself.
 $temp = New-InstallDirectory -Directory "<auto>" -Default ".temp" -Clean
 
-if ($FrameworkVersion -eq "<auto>")
-{
-    $FrameworkVersion = Get-FrameworkVersion
-}
+$Framework = $env:JITBENCH_TARGET_FRAMEWORK_MONIKER
+$FrameworkVersion = $env:JITBENCH_FRAMEWORK_VERSION
 
-if ($AspNetVersion -eq "<auto>")
-{
-    $AspNetVersion = Get-LatestAspNetVersion -InstallDir "<auto>"
-}
-
-# These environment variables are used by CreateStore.proj
-$env:JITBENCH_ASPNET_VERSION = $AspNetVersion
-$env:JITBENCH_FRAMEWORK_VERSION = $FrameworkVersion
-
-Write-Host -ForegroundColor Green "Running dotnet store"
-& "dotnet" "store", "--manifest", ".\CreateStore.proj", "-f", "$Framework", "-r" "$Runtime" "--framework-version", "$FrameworkVersion", "-w", $temp, "-o", "$InstallDir", "--skip-symbols"
+Write-Host -ForegroundColor Green "Running dotnet store --manifest .\CreateStore\CreateStore.proj -f" $Framework "-r" $Runtime "--framework-version" $FrameworkVersion "-w" $temp "-o" $InstallDir "--skip-symbols"
+& "dotnet" "store", "--manifest", ".\CreateStore\CreateStore.proj", "-f", "$Framework", "-r" "$Runtime" "--framework-version", "$FrameworkVersion", "-w", $temp, "-o", "$InstallDir", "--skip-symbols"
 if ($LastExitCode -ne 0)
 {
     throw "dotnet store failed."
 }
-
 $BinariesDirectory = $InstallDir
 $Manifest = [System.IO.Path]::Combine($InstallDir, $Architecture, $Framework, 'artifact.xml')
-
-Write-Host -ForegroundColor Green "Setting JITBENCH_ASPNET_VERSION to $AspNetVersion"
-$env:JITBENCH_ASPNET_VERSION = $AspNetVersion
-
-Write-Host -ForegroundColor Green "Setting JITBENCH_FRAMEWORK_VERSION to $FrameworkVersion"
-$env:JITBENCH_FRAMEWORK_VERSION = $FrameworkVersion
-
 Write-Host -ForegroundColor Green "Setting JITBENCH_ASPNET_MANIFEST to $Manifest"
-$env:JITBENCH_ASPNET_MANIFEST = $Manifest
 
 Write-Host -ForegroundColor Green "Setting DOTNET_SHARED_STORE to $BinariesDirectory"
 $env:DOTNET_SHARED_STORE = $BinariesDirectory

--- a/AspNet-SetVersions.ps1
+++ b/AspNet-SetVersions.ps1
@@ -1,0 +1,50 @@
+[cmdletbinding()]
+param(
+    [string] $AspNetVersion = "<auto>",
+    [string] $FrameworkVersion = "<auto>",
+    [string] $TargetFrameworkMoniker = "<auto>",
+    [string] $FrameworkSdkVersion = "<auto>",
+    [switch] $Clean
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference="Stop"
+$ProgressPreference="SilentlyContinue"
+
+. "$(Split-Path $MyInvocation.MyCommand.Path -Parent)\AspNet-Shared.ps1"
+
+$GlobalJsonPath = "$(Split-Path $MyInvocation.MyCommand.Path -Parent)\global.json"
+$versions = Calculate-Versions -AspNetVersion $AspNetVersion -FrameworkVersion $FrameworkVersion -TargetFrameworkMoniker $TargetFrameworkMoniker -FrameworkSdkVersion $FrameworkSdkVersion
+
+if($Clean -eq $true)
+{
+    foreach ($kvp in $versions.GetEnumerator())
+    {
+        Write-Host "Unsetting" $kvp.Key
+        [System.Environment]::SetEnvironmentVariable($kvp.Key, "")
+    }
+    Write-Host "Deleting $GlobalJsonPath"
+    if(Test-Path $GlobalJsonPath)
+    {
+        rm $GlobalJsonPath
+    }
+    return
+}
+Else
+{
+    foreach ($kvp in $versions.GetEnumerator())
+    {
+        Write-Host "Setting" $kvp.Key "to" $kvp.Value
+        [System.Environment]::SetEnvironmentVariable($kvp.Key, $kvp.Value)
+    }
+
+    $FrameworkSdkVersion = $versions["JITBENCH_FRAMEWORK_SDK_VERSION"]
+    Write-Host "Writing $GlobalJsonPath"
+    $ConfigText = "{
+    `"sdk`": 
+    {
+        `"version`": `"$FrameworkSdkVersion`"
+    }
+}"
+    Out-File -FilePath $GlobalJsonPath -InputObject $ConfigText -Encoding ASCII
+}

--- a/AspNet-Shared.ps1
+++ b/AspNet-Shared.ps1
@@ -1,5 +1,52 @@
 # Shared functions used by various scripts
 
+function Calculate-Versions(
+    [string] $AspNetVersion = "<auto>",
+    [string] $FrameworkVersion = "<auto>",
+    [string] $TargetFrameworkMoniker = "<auto>",
+    [string] $FrameworkSdkVersion = "<auto>")
+{
+    if($AspNetVersion -eq "<auto>")
+    {
+        $AspNetVersion = "2.0.0"
+    }
+
+    if($FrameworkVersion -eq "<auto>")
+    {
+        $FrameworkVersion = "2.0.0"
+    }
+
+    if($TargetFrameworkMoniker -eq "<auto>")
+    {
+        $TargetFrameworkMoniker = "netcoreapp" + $FrameworkVersion.Substring(0,3)
+    }
+
+    if($FrameworkSdkVersion -eq "<auto>")
+    {
+        if($TargetFrameworkMoniker -eq "netcoreapp2.0")
+        {
+            $FrameworkSdkVersion = "2.0.0"
+        }
+        ElseIf($TargetFrameworkMoniker -eq "netcoreapp2.1")
+        {
+            #This is an arbitrarily selected last known good SDK that works for netcoreapp2.1
+            $FrameworkSdkVersion = "2.2.0-preview1-007558"
+        }
+        Else
+        {
+            $errorMsg = "No default SDK version has been designated that supports TFM $TargetFrameworkMoniker"
+            throw $errorMsg
+        }
+    }
+
+    $ret = @{}
+    $ret.Add("JITBENCH_ASPNET_VERSION",$AspNetVersion)
+    $ret.Add("JITBENCH_FRAMEWORK_SDK_VERSION", $FrameworkSdkVersion)
+    $ret.Add("JITBENCH_TARGET_FRAMEWORK_MONIKER", $TargetFrameworkMoniker)
+    $ret.Add("JITBENCH_FRAMEWORK_VERSION", $FrameworkVersion)
+    return $ret
+}
+
 # Creates a directory if it doesn't exist, returns the fully qualified path
 function New-InstallDirectory(
     [string] $Directory,

--- a/CreateStore/CreateStore.proj
+++ b/CreateStore/CreateStore.proj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AspNetVersion>$(JITBENCH_ASPNET_VERSION)</AspNetVersion>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(JITBENCH_TARGET_FRAMEWORK_MONIKER)</TargetFramework>
+    <RuntimeFrameworkVersion>$(JITBENCH_FRAMEWORK_VERSION)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CreateStore/bugfix_sdk_1682/Microsoft.NET.ComposeStore.targets
+++ b/CreateStore/bugfix_sdk_1682/Microsoft.NET.ComposeStore.targets
@@ -1,0 +1,461 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.ComposeStore.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    ============================================================
+                                        ComposeStore
+ 
+    The main store entry point.
+    ============================================================
+    -->
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Target Name="ComposeStore"
+          DependsOnTargets="PrepareForComposeStore;
+                            PrepOptimizer;
+                            StoreWorkerMain;
+                            _CopyResolvedUnOptimizedFiles;
+                            StoreFinalizer;"/>
+
+  <!--
+    ============================================================
+                                        StoreWorkerMain
+
+   Processes the store project files
+    ============================================================
+    -->
+  
+  <Target Name="StoreWorkerMain">
+    
+    <ItemGroup>
+      <_AllProjects Include="$(AdditionalProjects.Split('%3B'))"/>
+      <_AllProjects Include ="$(MSBuildProjectFullPath)"/>
+    </ItemGroup>
+
+    <MSBuild Projects="%(_AllProjects.Identity)"
+                 Targets="StoreWorkerMapper"
+                 BuildinParallel="$(BuildinParallel)"
+                 Properties="ComposeWorkingDir=$(ComposeWorkingDir);
+                             PublishDir=$(PublishDir);
+                             StoreStagingDir=$(StoreStagingDir);
+                             TargetFramework=$(_TFM);
+                             JitPath=$(JitPath);
+                             Crossgen=$(Crossgen);
+                             DisableImplicitFrameworkReferences=true;
+                             SkipUnchangedFiles=$(SkipUnchangedFiles);
+                             PreserveStoreLayout=$(PreserveStoreLayout);
+                             CreateProfilingSymbols=$(CreateProfilingSymbols);
+                             StoreSymbolsStagingDir=$(StoreSymbolsStagingDir)"
+                 ContinueOnError="WarnAndContinue">
+      <Output ItemName="AllResolvedPackagesPublished" TaskParameter="TargetOutputs" />
+    </MSBuild>
+  </Target>
+  <!--
+    ============================================================
+                                        StoreWorkerMapper
+
+   Processes each package specified in a store project file
+    ============================================================
+    -->
+
+  <Target Name="StoreWorkerMapper"
+          Returns ="@(ResolvedPackagesFromMapper)">
+
+    <ItemGroup>
+      <PackageReferencesToStore Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>
+          StorePackageName=%(PackageReference.Identity);
+          StorePackageVersion=%(PackageReference.Version);
+          ComposeWorkingDir=$(ComposeWorkingDir);
+          PublishDir=$(PublishDir);
+          StoreStagingDir=$(StoreStagingDir);
+          TargetFramework=$(TargetFramework);
+          RuntimeIdentifier=$(RuntimeIdentifier);
+          JitPath=$(JitPath);
+          Crossgen=$(Crossgen);
+          SkipUnchangedFiles=$(SkipUnchangedFiles);
+          PreserveStoreLayout=$(PreserveStoreLayout);
+          CreateProfilingSymbols=$(CreateProfilingSymbols);
+          StoreSymbolsStagingDir=$(StoreSymbolsStagingDir);
+          DisableImplicitFrameworkReferences=false;
+        </AdditionalProperties>
+        <StorePackageName>%(PackageReference.Identity)</StorePackageName>
+        <StorePackageVersion>%(PackageReference.Version)</StorePackageVersion>
+      </PackageReferencesToStore>
+    </ItemGroup>
+
+<!-- Restore phase -->
+    <MSBuild Projects="@(PackageReferencesToStore)"
+                 Targets="RestoreForComposeStore"
+                 BuildInParallel="$(BuildInParallel)"
+                 ContinueOnError="WarnAndContinue">
+    </MSBuild>
+    
+    
+<!-- Resolve phase-->
+    <MSBuild Projects="@(PackageReferencesToStore)"
+                 Targets="StoreResolver"
+                 Properties="MSBuildProjectExtensionsPath=$(ComposeWorkingDir)\%(PackageReferencesToStore.StorePackageName)_$([System.String]::Copy('%(PackageReferencesToStore.StorePackageVersion)').Replace('*','-'))\;"
+                 BuildInParallel="$(BuildInParallel)"
+                 ContinueOnError="WarnAndContinue">
+      <Output ItemName="ResolvedPackagesFromMapper" TaskParameter="TargetOutputs" />
+    </MSBuild>
+  </Target>
+
+  <Target Name="StoreResolver"
+          Returns="@(ResolvedPackagesPublished)"
+          DependsOnTargets="PrepforRestoreForComposeStore;
+                            StoreWorkerPerformWork"/>
+  
+  <Target Name="StoreWorkerPerformWork"
+          DependsOnTargets="ComputeAndCopyFilesToStoreDirectory;"
+          Condition="Exists($(StoreWorkerWorkingDir))" />
+
+<!--
+    ============================================================
+                                        StoreFinalizer
+
+   Cleans up and produces artifacts after completion of store
+    ============================================================
+    -->
+  <UsingTask TaskName="RemoveDuplicatePackageReferences" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="StoreFinalizer"
+          DependsOnTargets="StoreWorkerMain;
+                            _CopyResolvedOptimizedFiles">
+
+    <RemoveDuplicatePackageReferences
+         InputPackageReferences="@(AllResolvedPackagesPublished)">
+      <Output TaskParameter="UniquePackageReferences"  ItemName="AllResolvedPackagesPublishedAfterFilter"/>
+    </RemoveDuplicatePackageReferences>
+    
+    <ItemGroup>
+      <ListOfPackageReference Include="@(AllResolvedPackagesPublishedAfterFilter -> '%20%20%20&lt;Package Id=&quot;%(Identity)&quot;  Version =&quot;%(Version)&quot;/&gt;')"/>
+    </ItemGroup>
+    <PropertyGroup>
+      <_StoreArtifactContent>
+      <![CDATA[
+<StoreArtifacts>
+@(ListOfPackageReference)
+</StoreArtifacts>
+]]>
+       </_StoreArtifactContent>
+      </PropertyGroup>
+    <WriteLinesToFile
+             File="$(StoreArtifactXml)"
+             Lines="$(_StoreArtifactContent)"
+             Overwrite="true" />
+
+    <Message Text="Files were composed in $(PublishDir)"
+                 Importance="high"/>
+    <Message Text="The list of packages stored is in $(StoreArtifactXml) "
+                 Importance="high"/>
+    <RemoveDir
+        Condition="'$(PreserveComposeWorkingDir)' != 'true'"
+        Directories="$(ComposeWorkingDir)"
+        ContinueOnError="WarnAndContinue"/>
+  </Target>
+
+  <!--
+    ============================================================
+                                        _CopyResolvedUnOptimizedFiles
+
+    Copy OptimizedResolvedFileToPublish items to the publish directory.
+    ============================================================
+    -->
+
+  <Target Name="_CopyResolvedOptimizedFiles"
+          DependsOnTargets="StoreWorkerMain;">
+    <ItemGroup>
+      <_OptimizedResolvedFileToPublish Include="$(StoreStagingDir)\**\*.*" />
+      <_OptimizedSymbolFileToPublish Include="$(StoreSymbolsStagingDir)\**\*.*" />
+    </ItemGroup>
+
+    <Copy SourceFiles = "@(_OptimizedResolvedFileToPublish)"
+          DestinationFolder="$(PublishDir)%(RecursiveDir)"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          Condition ="'@(_OptimizedResolvedFileToPublish)' != ''"
+          SkipUnchangedFiles="$(SkipUnchangedFiles)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
+
+    <Copy SourceFiles="@(_OptimizedSymbolFileToPublish)"
+          DestinationFolder="$(ProfilingSymbolsDir)%(RecursiveDir)"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          Condition="'@(_OptimizedSymbolFileToPublish)' != ''"
+          SkipUnchangedFiles="$(SkipUnchangedFiles)">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+    </Copy>
+  </Target>
+  
+  <!--
+    ============================================================
+                                        PrepareForComposeStore
+
+    Prepare the prerequisites for ComposeStore.
+    ============================================================
+    -->
+  
+  <Target Name="PrepareForComposeStore">
+
+    <PropertyGroup>
+      <PreserveStoreLayout Condition="'$(PreserveStoreLayout)' == ''">true</PreserveStoreLayout>
+      <SkipOptimization Condition="'$(RuntimeIdentifier)' == ''">true</SkipOptimization>
+      <_TFM Condition="'$(_TFM)' == ''">$(TargetFramework)</_TFM>
+      <SkipUnchangedFiles Condition="'$(SkipUnchangedFiles)' == ''">true</SkipUnchangedFiles>
+    </PropertyGroup>
+
+   <NETSdkError Condition="'2.0' > '$(_TargetFrameworkVersionWithoutV)'"
+                 ResourceName="NU1008"
+                 FormatArguments="$(TargetFrameworkMoniker)"/>
+
+    <NETSdkError Condition="'$(RuntimeIdentifier)' =='' and '$(_PureManagedAssets)' == ''"
+                 ResourceName="RuntimeIdentifierWasNotSpecified"/>
+
+    <NETSdkError Condition="'$(_TFM)' ==''"
+                 ResourceName="AtLeastOneTargetFrameworkMustBeSpecified"/>
+      
+    <PropertyGroup>
+      <DefaultComposeDir>$(UserProfileRuntimeStorePath)</DefaultComposeDir>
+
+      <_ProfilingSymbolsDirectoryName>symbols</_ProfilingSymbolsDirectoryName>
+      <DefaultProfilingSymbolsDir>$([System.IO.Path]::Combine($(DefaultComposeDir), $(_ProfilingSymbolsDirectoryName)))</DefaultProfilingSymbolsDir>
+      <ProfilingSymbolsDir Condition="'$(ProfilingSymbolsDir)' == '' and '$(ComposeDir)' != ''">$([System.IO.Path]::Combine($(ComposeDir), $(_ProfilingSymbolsDirectoryName)))</ProfilingSymbolsDir>
+      <ProfilingSymbolsDir Condition="'$(ProfilingSymbolsDir)' != '' and '$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ProfilingSymbolsDir), $(PlatformTarget)))</ProfilingSymbolsDir>
+      <ProfilingSymbolsDir Condition="'$(ProfilingSymbolsDir)' == ''">$(DefaultProfilingSymbolsDir)</ProfilingSymbolsDir>
+      <ProfilingSymbolsDir Condition="'$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ProfilingSymbolsDir), $(_TFM)))</ProfilingSymbolsDir>
+      <ProfilingSymbolsDir Condition="!HasTrailingSlash('$(ProfilingSymbolsDir)')">$(ProfilingSymbolsDir)\</ProfilingSymbolsDir>
+
+      <ComposeDir Condition="'$(ComposeDir)' == ''">$(DefaultComposeDir)</ComposeDir>
+      <ComposeDir Condition="'$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ComposeDir), $(PlatformTarget)))</ComposeDir>
+      <ComposeDir Condition="'$(DoNotDecorateComposeDir)' != 'true'">$([System.IO.Path]::Combine($(ComposeDir), $(_TFM)))</ComposeDir>
+      <StoreArtifactXml>$([System.IO.Path]::Combine($(ComposeDir),"artifact.xml"))</StoreArtifactXml>
+      <PublishDir>$([System.IO.Path]::GetFullPath($(ComposeDir)))</PublishDir>
+      <_RandomFileName>$([System.IO.Path]::GetRandomFileName())</_RandomFileName>
+      <TEMP Condition="'$(TEMP)' == ''">$([System.IO.Path]::GetTempPath())</TEMP>
+      <ComposeWorkingDir Condition="'$(ComposeWorkingDir)' == ''">$([System.IO.Path]::Combine($(TEMP), $(_RandomFileName)))</ComposeWorkingDir>
+      <ComposeWorkingDir>$([System.IO.Path]::GetFullPath($(ComposeWorkingDir)))</ComposeWorkingDir>
+      <StoreStagingDir>$([System.IO.Path]::Combine($(ComposeWorkingDir),"StagingDir"))</StoreStagingDir>      <!-- Will contain optimized managed assemblies in nuget cache layout -->
+      <StoreSymbolsStagingDir>$([System.IO.Path]::Combine($(ComposeWorkingDir),"SymbolsStagingDir"))</StoreSymbolsStagingDir>
+      <!-- Ensure any PublishDir has a trailing slash, so it can be concatenated -->
+      <PublishDir Condition="!HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="'$(CreateProfilingSymbols)' == ''">
+      <!-- There is no support for profiling symbols on OSX -->
+      <CreateProfilingSymbols Condition="$(RuntimeIdentifier.StartsWith('osx'))">false</CreateProfilingSymbols>
+      <CreateProfilingSymbols Condition="'$(CreateProfilingSymbols)' == ''">true</CreateProfilingSymbols>
+    </PropertyGroup>
+
+    <NETSdkError Condition="Exists($(ComposeWorkingDir))"
+                 ResourceName="FolderAlreadyExists"
+                 FormatArguments="$(ComposeWorkingDir)" />
+
+    <MakeDir Directories="$(PublishDir)" />
+    <MakeDir  Directories="$(StoreStagingDir)"/>
+
+  </Target>
+
+  <Target Name="PrepforRestoreForComposeStore"
+          DependsOnTargets="_DefaultMicrosoftNETPlatformLibrary">
+
+    <PropertyGroup>
+      <StorePackageVersionForFolderName>$(StorePackageVersion.Replace('*','-'))</StorePackageVersionForFolderName>
+      <StoreWorkerWorkingDir>$([System.IO.Path]::Combine($(ComposeWorkingDir),"$(StorePackageName)_$(StorePackageVersionForFolderName)"))</StoreWorkerWorkingDir>
+      <_PackageProjFile>$([System.IO.Path]::Combine($(StoreWorkerWorkingDir), "Restore.csproj"))</_PackageProjFile>
+      <BaseIntermediateOutputPath>$(StoreWorkerWorkingDir)\</BaseIntermediateOutputPath>
+      <ProjectAssetsFile>$(BaseIntermediateOutputPath)\project.assets.json</ProjectAssetsFile>
+    </PropertyGroup>
+    
+    <PropertyGroup>
+      <PackagesToPrune>$(MicrosoftNETPlatformLibrary)</PackagesToPrune>
+      <SelfContained Condition="'$(SelfContained)' == ''">true</SelfContained>
+    </PropertyGroup>
+  </Target>
+  
+  <!--
+    ============================================================
+                                        RestoreForComposeStore
+
+    Restores the package
+    ============================================================
+    -->
+  
+  <Target Name="RestoreForComposeStore"
+          DependsOnTargets="PrepforRestoreForComposeStore;"
+          Condition="!Exists($(StoreWorkerWorkingDir))">
+    
+    <MakeDir Directories="$(StoreWorkerWorkingDir)" />
+    
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+                 Targets="Restore"
+                 Properties="RestoreGraphProjectInput=$(MSBuildProjectFullPath);
+                             RestoreOutputPath=$(BaseIntermediateOutputPath);
+                             StorePackageName=$(StorePackageName);
+                             StorePackageVersion=$(StorePackageVersion);
+                             RuntimeIdentifier=$(RuntimeIdentifier);
+                             TargetFramework=$(TargetFramework);"/>
+  </Target>
+
+  <!--
+    ============================================================
+                                        ComputeAndCopyFilesToStoreDirectory
+
+    Computes the list of all files to copy to the publish directory and then publishes them.
+    ============================================================
+    -->
+  
+  <Target Name="ComputeAndCopyFilesToStoreDirectory"
+          DependsOnTargets="ComputeFilesToStore;
+                            CopyFilesToStoreDirectory" />
+
+  <!--
+    ============================================================
+                                        CopyFilesToStoreDirectory
+
+    Copy all build outputs, satellites and other necessary files to the publish directory.
+    ============================================================
+    -->
+  
+  <Target Name="CopyFilesToStoreDirectory"
+          DependsOnTargets="_CopyResolvedUnOptimizedFiles"/>
+  
+  
+  <!--
+    ============================================================
+                                        _CopyResolvedUnOptimizedFiles
+
+    Copy _UnOptimizedResolvedFileToPublish items to the publish directory.
+    ============================================================
+    -->
+  
+  <Target Name="_CopyResolvedUnOptimizedFiles"
+          DependsOnTargets="_ComputeResolvedFilesToStoreTypes;
+                            _RunOptimizer">
+
+    <Copy SourceFiles = "@(_UnOptimizedResolvedFileToPublish)"
+          DestinationFiles="$(PublishDir)%(_UnOptimizedResolvedFileToPublish.DestinationSubPath)"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          SkipUnchangedFiles="$(SkipUnchangedFiles)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
+  </Target>
+
+  <!--
+    ============================================================
+                                        _ComputeResolvedFilesToStoreTypes
+    ============================================================
+    -->
+  
+  <Target Name="_ComputeResolvedFilesToStoreTypes"
+           DependsOnTargets="_GetResolvedFilesToStore;_SplitResolvedFiles;" />
+
+  <!--
+    ============================================================
+                                        _SplitResolvedFiles
+
+    Splits ResolvedFileToPublish items into 'managed' and 'unmanaged' buckets.
+    ============================================================
+    -->
+  
+  <Target Name="_SplitResolvedFiles"
+           Condition="$(SkipOptimization) !='true' "
+           DependsOnTargets="_GetResolvedFilesToStore">
+    <ItemGroup>
+      <_ManagedResolvedFileToPublishCandidates Include="@(ResolvedFileToPublish)"
+                                             Condition="'%(ResolvedFileToPublish.AssetType)'=='runtime'" />
+
+      <_UnOptimizedResolvedFileToPublish Include="@(ResolvedFileToPublish)"
+                                     Condition="'%(ResolvedFileToPublish.AssetType)'!='runtime'" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <SkipOptimization Condition="'@(_ManagedResolvedFileToPublishCandidates)'==''">true</SkipOptimization>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    ============================================================
+                                        _GetResolvedFilesToStore
+    ============================================================
+    -->
+  
+  <Target Name="_GetResolvedFilesToStore"
+           Condition="$(SkipOptimization) == 'true' ">
+    <ItemGroup>
+            <_UnOptimizedResolvedFileToPublish Include="@(ResolvedFileToPublish)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ============================================================
+                                        ComputeFilesToStore
+
+    Gathers all the files that need to be copied to the publish directory.
+    ============================================================
+    -->
+  <UsingTask TaskName="FilterResolvedFiles" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <Target Name="ComputeFilesToStore"
+          DependsOnTargets="_ComputeNetPublishAssets;
+                            _ComputeCopyToPublishDirectoryItems">
+
+    <PropertyGroup>
+      <CopyBuildOutputToPublishDirectory Condition="'$(CopyBuildOutputToPublishDirectory)'==''">true</CopyBuildOutputToPublishDirectory>
+      <CopyOutputSymbolsToPublishDirectory Condition="'$(CopyOutputSymbolsToPublishDirectory)'==''">true</CopyOutputSymbolsToPublishDirectory>
+    </PropertyGroup>
+
+    <FilterResolvedFiles  AssetsFilePath="$(ProjectAssetsFile)"
+                           ResolvedFiles ="@(ResolvedAssembliesToPublish)"
+                           PackagesToPrune="$(PackagesToPrune)"
+                           TargetFramework="$(TargetFrameworkMoniker)"
+                           RuntimeIdentifier="$(RuntimeIdentifier)"
+                           IsSelfContained="$(SelfContained)" >
+      <Output TaskParameter="AssembliesToPublish" ItemName="ResolvedFileToPublish" />
+      <Output TaskParameter="PublishedPackges" ItemName="PackagesThatWereResolved" />
+    </FilterResolvedFiles>
+
+    <ItemGroup>
+      <ResolvedPackagesPublished Include="@(PackagesThatWereResolved)"
+                                    Condition="$(DoNotTrackPackageAsResolved) !='true'"/>
+    </ItemGroup>
+    
+  </Target>
+
+  <!--
+    ============================================================
+                                       PrepRestoreForStoreProjects 
+
+    Removes specified PackageReference for store and inserts the specified StorePackageName
+    ============================================================
+    -->
+  <Target Name="PrepRestoreForStoreProjects"
+          BeforeTargets="_GenerateProjectRestoreGraphPerFramework;"
+          Condition="'$(StorePackageName)' != ''" >
+    
+    <ItemGroup>
+      <PackageReference Remove="@(PackageReference)" Condition="'%(PackageReference.IsImplicitlyDefined)' != 'true'"/>
+      <PackageReference Include="$(StorePackageName)" Version="$(StorePackageVersion)"/>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/GetLatestAspNetVersion.proj
+++ b/GetLatestAspNetVersion.proj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0</AspNetCoreVersion>
     <RuntimeFrameworkVersion>2.0.0-*</RuntimeFrameworkVersion>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RunBenchmark.ps1
+++ b/RunBenchmark.ps1
@@ -1,0 +1,141 @@
+[cmdletbinding()]
+param(
+    [string] $AspNetVersion = "<auto>",
+    [string] $FrameworkVersion = "<auto>",
+    [string] $TargetFrameworkMoniker = "<auto>",
+    [string] $FrameworkSdkVersion = "<auto>",
+    [string] $Architecture = "x64",
+    [string] $Rid = "win7-x64",
+    [switch] $PrecompiledViews,
+    [string] $PrivateCoreCLRBinDirPath,
+    [switch] $SetupOnly,
+    [switch] $WhatIf)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference="Stop"
+$ProgressPreference="SilentlyContinue"
+
+$ScriptDir = $(Split-Path $MyInvocation.MyCommand.Path -Parent)
+. "$ScriptDir\AspNet-Shared.ps1"
+
+function Run-Cmd
+{
+    Param($Cmd)
+    if($WhatIf -ne $true)
+    {
+        Write-Host -ForegroundColor Green $Cmd
+        Invoke-Expression $Cmd
+        Write-Host ""
+    }
+    else
+    {
+        Write-Host $Cmd
+    }
+}
+
+Write-Host -ForegroundColor Green " ***** Step 1 - Set Versions *******"
+$cmd = "cd $ScriptDir"
+Run-Cmd $cmd
+
+$cmd = ".\AspNet-SetVersions.ps1"
+if($AspNetVersion -ne "<auto>")
+{
+    $cmd += " -AspNetVersion $AspNetVersion"
+}
+if($FrameworkVersion -ne "<auto>")
+{
+    $cmd += " -FrameworkVersion $FrameworkVersion"
+}
+if($TargetFrameworkMoniker -ne "<auto>")
+{
+    $cmd += " -TargetFrameworkMoniker $TargetFrameworkMoniker"
+}
+if($FrameworkSdkVersion -ne "<auto>")
+{
+    $cmd += " -FrameworkSdkVersion $FrameworkSdkVersion"
+}
+Run-Cmd $cmd
+$vars = Calculate-Versions -AspNetVersion $AspNetVersion -FrameworkVersion $FrameworkVersion -TargetFrameworkMoniker $TargetFrameworkMoniker -FrameworkSdkVersion $FrameworkSdkVersion
+Write-Host ""
+
+
+Write-Host -ForegroundColor Green " ***** Step 2 - Setup Dotnet Runtime and SDK *******"
+$cmd = ".\DotNet-Install.ps1 -SharedRuntime -InstallDir .dotnet -Channel master -Version " + $vars.Item("JITBENCH_FRAMEWORK_VERSION") + " -Architecture " + $Architecture
+Run-Cmd $cmd
+
+$cmd = ".\DotNet-Install.ps1 -InstallDir .dotnet -Channel master -Version " + $vars.Item("JITBENCH_FRAMEWORK_SDK_VERSION") + " -Architecture " + $Architecture
+Run-Cmd $cmd
+
+if($PrivateCoreCLRBinDirPath -ne "")
+{
+    $cmd = ".\AspNet-CopyPrivateCoreCLR.ps1 -BinDirPath $PrivateCoreCLRBinDirPath"
+    Run-Cmd $cmd
+}
+
+
+Write-Host ""
+
+
+Write-Host -ForegroundColor Green " ***** Step 3 - Generate Store *******"
+#Workaround for SDK bug 1682
+$cmd = "cp ./CreateStore/bugfix_sdk_1682/Microsoft.NET.ComposeStore.targets .dotnet/sdk/" + $vars.Item("JITBENCH_FRAMEWORK_SDK_VERSION") + "/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.ComposeStore.targets"
+Run-Cmd $cmd
+
+$cmd = ".\AspNet-GenerateStore.ps1 -InstallDir .store -Architecture $Architecture -Runtime $Rid"
+Run-Cmd $cmd
+$InstallDir = "$ScriptDir\.store"
+$ManifestPath = [System.IO.Path]::Combine($InstallDir, $Architecture, $vars.Item("JITBENCH_TARGET_FRAMEWORK_MONIKER"), "artifact.xml")
+Write-Host ""
+
+
+Write-Host -ForegroundColor Green " ***** Step 4 - Restore MusicStore *******"
+$cmd = "cd src\MusicStore"
+Run-Cmd $cmd
+
+$cmd = "dotnet restore"
+Run-Cmd $cmd
+Write-Host ""
+
+
+Write-Host -ForegroundColor Green " ***** Step 5 - Publish MusicStore *******"
+
+#Publish doesn't clean the results of old publishing before doing the new one. If you switch back and forth between
+#precompiled views the stale precompilation results will still be there. I assume asp.net uses them if they are present
+#though I haven't confirmed.
+$pathToPublishDir = "bin\Release\" + $vars.Item("JITBENCH_TARGET_FRAMEWORK_MONIKER") + "\publish"
+if(Test-Path $pathToPublishDir)
+{
+    $cmd = "rm -r " + $pathToPublishDir
+    Run-Cmd $cmd
+}
+
+$cmd = "dotnet publish -c Release -f " + $vars.Item("JITBENCH_TARGET_FRAMEWORK_MONIKER") + " --manifest " + $ManifestPath
+if($PrecompiledViews -eq $true)
+{
+    $cmd += " /p:MvcRazorCompileOnPublish=true"
+}
+else
+{
+    $cmd += " /p:MvcRazorCompileOnPublish=false"
+}
+Run-Cmd $cmd
+Write-Host ""
+
+
+Write-Host -ForegroundColor Green " ***** Step 6 - Run MusicStore *******"
+if($SetupOnly -eq $true)
+{
+    Write-Host "-SetupOnly flag was passed, skipping execution"
+}
+else
+{
+    $cmd = "cd " + $pathToPublishDir
+    Run-Cmd $cmd
+
+    $cmd = "dotnet MusicStore.dll"
+    Run-Cmd $cmd
+}
+Write-Host ""
+
+
+. cd $ScriptDir

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -16,10 +16,10 @@ Set-Location src\MusicStore
 dotnet restore
 
 Write-Host -ForegroundColor Green "Publishing MusicStore"
-dotnet publish -c Release -f netcoreapp2.1 --manifest $env:JITBENCH_ASPNET_MANIFEST
+dotnet publish -c Release -f netcoreapp2.0 --manifest $env:JITBENCH_ASPNET_MANIFEST
 
 Write-Host -ForegroundColor Green "Running MusicStore"
-Set-Location bin\Release\netcoreapp2.1\publish
+Set-Location bin\Release\netcoreapp2.0\publish
 dotnet .\MusicStore.dll | Tee-Object -Variable output
 
 if (-not ($output.Contains("ASP.NET loaded from store")))

--- a/aspnet-generatestore.sh
+++ b/aspnet-generatestore.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 install_dir="<auto>"
 aspnet_version="2.0.0"
-framework="netcoreapp2.1"
+framework="netcoreapp2.0"
 framework_version="<auto>"
 architecture="x64"
 runtime_id="" # must be provided
@@ -124,7 +124,7 @@ export JITBENCH_ASPNET_VERSION="$aspnet_version"
 export JITBENCH_FRAMEWORK_VERSION="$framework_version"
 
 echo "Running dotnet store"
-dotnet store --manifest "./CreateStore.proj" -f "$framework" -r "$runtime_id" --framework-version "$framework_version" -w "$work_dir" -o "$install_dir" --skip-symbols
+dotnet store --manifest "./CreateStore/CreateStore.proj" -f "$framework" -r "$runtime_id" --framework-version "$framework_version" -w "$work_dir" -o "$install_dir" --skip-symbols
 
 manifest="$install_dir/$architecture/$framework/artifact.xml"
 

--- a/src/MusicStore/MusicStore.csproj
+++ b/src/MusicStore/MusicStore.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Description>Music store application on ASP.NET 5</Description>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(JITBENCH_TARGET_FRAMEWORK_MONIKER)</TargetFramework>
+    <TargetFramework Condition="'$(TargetFramework)'==''">netcoreapp2.0</TargetFramework>
     <DefineConstants>$(DefineConstants);DEMO</DefineConstants>
     <WarningsAsErrors>true</WarningsAsErrors>
     <PreserveCompilationContext>true</PreserveCompilationContext>
@@ -26,7 +27,7 @@
     <AspNetVersion>2.0.0</AspNetVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RuntimeFrameworkVersion)' == '' ">
-    <RuntimeFrameworkVersion>2.1.0-*</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/MusicStore/Program.cs
+++ b/src/MusicStore/Program.cs
@@ -28,7 +28,7 @@ namespace MusicStore
                 .ConfigureLogging(factory =>
                 {
                     factory.AddConsole();
-                    factory.AddFilter((category, level) => level >= LogLevel.Warning);
+                    factory.AddFilter((provider,category, level) => level >= LogLevel.Warning);
                 })
                 .UseKestrel();
 

--- a/travis.sh
+++ b/travis.sh
@@ -13,10 +13,13 @@ then
 fi
 
 echo "Installing latest dotnet"
-./dotnet-install.sh -sharedruntime -runtimeid "$shared_framework_runtime" -installdir .dotnet -channel master -architecture x64
-source ./dotnet-install.sh -installdir .dotnet -channel master -architecture x64
+./dotnet-install.sh -sharedruntime -runtimeid "$shared_framework_runtime" -installdir .dotnet -version 2.0.0 -architecture x64
+source ./dotnet-install.sh -installdir .dotnet -version 2.0.0 -architecture x64
 
 dotnet --info
+
+echo "Applying workaround for SDK bug 1682"
+cp ./CreateStore/bugfix_sdk_1682/Microsoft.NET.ComposeStore.targets ./.dotnet/sdk/2.0.0/Sdks/Microsoft.NET.Sdk/build/Microsoft.NET.ComposeStore.targets
 
 echo "Creating local package store"
 source ./aspnet-generatestore.sh -i .store --arch x64 -r "$runtime"
@@ -26,10 +29,10 @@ cd src/MusicStore
 dotnet restore
 
 echo "Publishing MusicStore"
-dotnet publish -c Release -f netcoreapp2.1 --manifest $JITBENCH_ASPNET_MANIFEST
+dotnet publish -c Release -f netcoreapp2.0 --manifest $JITBENCH_ASPNET_MANIFEST
 
 echo "Running MusicStore"
-cd bin/Release/netcoreapp2.1/publish
+cd bin/Release/netcoreapp2.0/publish
 output=$(dotnet ./MusicStore.dll | tee /dev/tty; exit ${PIPESTATUS[0]})
 
 if [[ "$output" != *"ASP.NET loaded from store"* ]]


### PR DESCRIPTION
The latest version of these RunBenchmark changes updated for some merge issues and added support for doing Precompiled views. Hopefully the README is self-explanatory on how this works but happy to make updates as needed.

I haven't made any corresponding changes for Linux/Mac, but since I think most of the current benchmarking is happening on windows I want to get that unblocked. I see no reason we couldn't make a similar script for Linux/Mac as soon as we are ready expand the benchmarking effort to those platforms.