### PR TITLE
Improve JitBench measurements

### DIFF
--- a/src/MusicStore/MusicStoreEventSource.cs
+++ b/src/MusicStore/MusicStoreEventSource.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics.Tracing;
+
+[EventSource(Name="MusicStore")]
+public class MusicStoreEventSource : EventSource
+{
+    [Event(1)]
+    public void ServerStartupBegin()
+    {
+        WriteEvent(1);
+    }
+
+    [Event(2)]
+    public void ServerStartupEnd(int serverStartMs)
+    {
+        WriteEvent(2, serverStartMs);
+    }
+
+    [Event(3)]
+    public void FirstRequestBegin()
+    {
+        WriteEvent(3);
+    }
+
+    [Event(4)]
+    public void FirstRequestEnd(int firstRequestMs)
+    {
+        WriteEvent(4, firstRequestMs);
+    }
+
+    [Event(5)]
+    public void RequestBatchBegin(int batchNumber, int requestCount)
+    {
+        WriteEvent(5, batchNumber, requestCount);
+    }
+
+    [Event(6)]
+    public void RequestBatchEnd(int batchNumber, int requestCount, int batchTimeMs, double minRequestTimeMs, double maxRequestTimeMs)
+    {
+        WriteEvent(6, batchNumber, requestCount, batchTimeMs, minRequestTimeMs, maxRequestTimeMs);
+    }
+}

--- a/src/MusicStore/MusicStoreEventSource.cs
+++ b/src/MusicStore/MusicStoreEventSource.cs
@@ -34,8 +34,8 @@ public class MusicStoreEventSource : EventSource
     }
 
     [Event(6)]
-    public void RequestBatchEnd(int batchNumber, int requestCount, int batchTimeMs, double minRequestTimeMs, double maxRequestTimeMs)
+    public void RequestBatchEnd(int batchNumber, int requestCount, int batchTimeMs, double minRequestTimeMs, double meanRequestTimeMs, double medianRequestTimeMs, double maxRequestTimeMs, double standardErrorMs)
     {
-        WriteEvent(6, batchNumber, requestCount, batchTimeMs, minRequestTimeMs, maxRequestTimeMs);
+        WriteEvent(6, batchNumber, requestCount, batchTimeMs, minRequestTimeMs, meanRequestTimeMs, medianRequestTimeMs, maxRequestTimeMs, standardErrorMs);
     }
 }

--- a/travis.sh
+++ b/travis.sh
@@ -35,9 +35,9 @@ echo "Running MusicStore"
 cd bin/Release/netcoreapp2.0/publish
 output=$(dotnet ./MusicStore.dll | tee /dev/tty; exit ${PIPESTATUS[0]})
 
-if [[ "$output" != *"ASP.NET loaded from store"* ]]
+if [[ "$output" == *"ASP.NET loaded from bin"* ]]
 then
-    echo "ASP.NET was not loaded from the store. This is a bug."
+    echo "ASP.NET was not loaded from the store. This is a bug. CI will now fail."
     exit 1
 fi
 


### PR DESCRIPTION
Improvements:
1) Instead of 100 iterations we now run 10,000 to calculate a steady state average. Extrapolating the time to run 10,000 requests by measuring the first 500 requests is off by about 3% on my machine and presumably the error margin is even higher on the first 100. The cost for this is that now the benchmark runs about 1 minute. If anyone has a particular use for the lower accuracy 100 iteration measurement we could always parameterize something. If you just want a fast steadystate measurement the new "-skipSteadyState" argument will give you that.
2) Added a breakdown that shows steadystate performance over different ranges of initial requests. This should help us measure the impact of defering background jitting a few seconds into app execution and also be able to see the longer term averages. We might need to fiddle with the exact ranges though, this was just a guess.
3) Used the high performance counter when available to get more accurate min/max timings.
4) In place of average request time I computed its inverse, request/sec.
5) Added ETW events so that an ETW listener can capture/reproduce all the info that is being logged to the console.
6) Cleaned up the console output to make it a bit easier to read (IMO at least). New output looks like this

````
dotnet MusicStore.dll
============= Startup Performance ============

Server start (ms):  1792
1st Request (ms):   5235
Total (ms):         7027

========== Steady State Performance ==========

  Requests    Aggregate Time(ms)    Req/s   Request Min(ms)   Request Max(ms)
-----------   ------------------   ------   ---------------   ---------------
    1-  500                 1872   267.05              3.05             12.14
  501- 1000                 3796   259.81              3.15             22.73
 1001- 1500                 5630   272.61              2.90              5.82
 1501- 2000                 7457   273.70              2.95             12.74
 2001-10000                36345   276.94              2.68             30.03

Tip: If you only care about startup performance, use the -skipSteadyState argument to skip these measurements
````