### PR TITLE
Use AspNetCoreModuleV2

### DIFF
--- a/src/MusicStore/web.config
+++ b/src/MusicStore/web.config
@@ -2,7 +2,7 @@
 <configuration>
   <system.webServer>
     <handlers>
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="true"/>
   </system.webServer>


### PR DESCRIPTION
We now get the following error when trying to build MusicStore: 

```
C:\michelm\JitBench\.dotnet\sdk\3.0.100-preview-009820\Sdks\Microsoft.NET.Sdk.Publish\build\netstandard1.0\TransformTarg
ets\Microsoft.NET.Sdk.Publish.TransformFiles.targets(49,5): error MSB4018: The "TransformWebConfig" task failed unexpectedly. [C:\michelm\JitBench\src\MusicStore\MusicStore.csproj]                                                            C:\michelm\JitBench\.dotnet\sdk\3.0.100-preview-009820\Sdks\Microsoft.NET.Sdk.Publish\build\netstandard1.0\TransformTarg
ets\Microsoft.NET.Sdk.Publish.TransformFiles.targets(49,5): error MSB4018: System.Exception: In process hosting is not supported for AspNetCoreModule. Change the AspNetCoreModule to at least AspNetCoreModuleV2. [C:\michelm\JitBench\src\MusicStore\MusicStore.csproj]                                            
```

Following the error message and changing the module to AspNetCoreModuleV2 fixes the error.